### PR TITLE
ci(k8s): AWS 배포용 backend.yaml 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,54 @@
+name: Build & Deploy Balgoorm BE
+
+on:
+  push:
+    branches: [ main ]
+    paths: [ 'src/**', 'Dockerfile', '.github/workflows/**' ]
+
+env:
+  AWS_REGION: ${{ secrets.AWS_REGION }}
+  ECR_REPO: 997252008275.dkr.ecr.ap-northeast-2.amazonaws.com/balgoorm-backend
+  LIGHTSAIL_SERVICE: balgoorm-be
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id:     ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region:            ${{ env.AWS_REGION }}
+
+      - name: Build & push to ECR
+        run: |
+          docker build -t balgoorm-backend:${{ github.sha }} .
+          aws ecr get-login-password --region $AWS_REGION | \
+            docker login --username AWS --password-stdin 997252008275.dkr.ecr.$AWS_REGION.amazonaws.com
+          docker tag balgoorm-backend:${{ github.sha }} $ECR_REPO:${{ github.sha }}
+          docker push $ECR_REPO:${{ github.sha }}
+
+      - name: Deploy latest image to Lightsail
+        run: |
+          aws lightsail push-container-image \
+            --service-name $LIGHTSAIL_SERVICE \
+            --image $ECR_REPO:${{ github.sha }} \
+            --label ${{ github.sha }}
+
+          cat <<EOF > tmp.json
+          {
+            "$LIGHTSAIL_SERVICE": {
+              "image": "$ECR_REPO:${{ github.sha }}",
+              "ports": { "8080": "HTTP" }
+            }
+          }
+          EOF
+
+          aws lightsail create-container-service-deployment \
+            --service-name $LIGHTSAIL_SERVICE \
+            --containers file://tmp.json \
+            --public-endpoint '{"containerName":"'"$LIGHTSAIL_SERVICE"'","containerPort":8080,"healthCheck":{"path":"/api/test","successCodes":"200-399"}}'


### PR DESCRIPTION
### 💡 목적 (Why)
- 크램폴린IDE를 이용한 배포에서 AWS Lightsail 배포로 변경하기 위해
- `main` 브랜치에 커밋될 때마다 Balgoorm IDE 백엔드를 AWS Lightsail에 자동으로 배포하기 위해
- 수동 Docker 빌드·푸시 과정을 제거하여 배포 신뢰도 및 속도 향상

### 🛠 변경 사항 (What)
- `.github/workflows/deploy.yml` 파일 추가  
  - Docker 이미지 빌드 → ECR Push → Lightsail 컨테이너 배포  
  - `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_REGION` 사용  
- 기존 수동 배포 문서(`README.md`)에 “CI 배포 배지” 추가 (배지 URL 삽입 예정)

### ✅ 결과 (Result)
- `main` 브랜치에 푸시 시 자동으로 최신 이미지가 Lightsail에 배포됨  
- PR 머지 후 Actions 탭 로그에서 배포 여부 확인 가능  
- 포트폴리오의 **[Live]** 링크(`https://api.balgoorm.dev`) 200 OK 동작 확인 완료

---

> **검증 방법**
> 1. Actions 탭 → “Build & Deploy Balgoorm BE” 워크플로 레드그린 확인  
> 2. `curl -I https://api.balgoorm.dev/api/test` → `200 OK` 반환  
> 3. 포트폴리오·README의 Live 링크가 최신 이미지로 반영