### PR TITLE
Refactor: DataInitializer 관리자 계정 정보 상수화 및 생성일 자동화

### DIFF
--- a/src/main/java/com/balgoorm/balgoorm_backend/DataInitializer.java
+++ b/src/main/java/com/balgoorm/balgoorm_backend/DataInitializer.java
@@ -8,21 +8,28 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-import java.time.LocalDateTime;
-
+/**
+ * 서버 시작 시 관리자(admin) 계정이 없으면 자동 생성하는 초기화 클래스
+ */
 @Configuration
 public class DataInitializer {
+
+    // 관리자 계정 상수 선언
+    private static final String ADMIN_ID = "admin";
+    private static final String ADMIN_PW = "admin123";
+    private static final String ADMIN_NICKNAME = "Administrator";
+    private static final String ADMIN_EMAIL = "admin@example.com";
 
     @Bean
     public ApplicationRunner initializer(UserRepository userRepository, PasswordEncoder passwordEncoder) {
         return args -> {
-            if (!userRepository.findByUserId("admin").isPresent()) {
+            // admin 계정이 없으면 신규 생성
+            if (userRepository.findByUserId(ADMIN_ID).isEmpty()) {
                 User adminUser = User.builder()
-                        .userId("admin")
-                        .userPassword(passwordEncoder.encode("admin123"))
-                        .nickname("Administrator")
-                        .email("admin@example.com")
-                        .createDate(LocalDateTime.now())
+                        .userId(ADMIN_ID)
+                        .userPassword(passwordEncoder.encode(ADMIN_PW))
+                        .nickname(ADMIN_NICKNAME)
+                        .email(ADMIN_EMAIL)
                         .role(UserRole.ADMIN)
                         .build();
                 userRepository.save(adminUser);

--- a/src/main/java/com/balgoorm/balgoorm_backend/user/auth/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/com/balgoorm/balgoorm_backend/user/auth/CustomAuthenticationSuccessHandler.java
@@ -1,43 +1,50 @@
 package com.balgoorm.balgoorm_backend.user.auth;
 
-
 import com.balgoorm.balgoorm_backend.user.model.entity.UserRole;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
-
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Spring Security 로그인 성공시 실행되는 커스텀 핸들러
+ * - 성공 응답을 JSON 구조로 반환
+ */
 @Component
 public class CustomAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
 
     private final ObjectMapper objectMapper;
 
+    // ObjectMapper는 Spring에서 자동 주입 받음
     public CustomAuthenticationSuccessHandler(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
+    /**
+     * 로그인 성공 시 호출되는 메서드
+     * - 사용자 PK, ROLE 정보를 JSON으로 반환
+     */
     @Override
-    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
-
-
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
+        // 인증된 사용자 정보 추출
         CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
-        Long id = userDetails.getUser().getId(); // 식별자
-        UserRole role = userDetails.getUser().getRole(); // 유저 ROLE
+        Long id = userDetails.getUser().getId();         // 사용자 PK
+        UserRole role = userDetails.getUser().getRole(); // 사용자 권한
+
+        // 응답 구조 정의 (실무에서는 키 이름 통일, 타입 맞추는 것 중요!)
+        Map<String, Object> result = new HashMap<>();
+        result.put("id", id);            // 숫자 그대로 전달
+        result.put("role", role.name()); // Enum값 문자열로
 
         response.setStatus(HttpServletResponse.SC_OK);
-        Map<String, String> result = new HashMap<>();
-        result.put("role", role+"");
-        result.put("userId", id+"");
-
-        response.setContentType("application/json");
-        response.setCharacterEncoding("UTF-8");
+        response.setContentType("application/json;charset=UTF-8");
+        // JSON으로 변환하여 응답
         response.getWriter().write(objectMapper.writeValueAsString(result));
     }
 }

--- a/src/main/java/com/balgoorm/balgoorm_backend/user/auth/CustomUserDetails.java
+++ b/src/main/java/com/balgoorm/balgoorm_backend/user/auth/CustomUserDetails.java
@@ -8,52 +8,72 @@ import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 
+/**
+ * Spring Security 인증 객체(Principal) 역할
+ * - 인증된 사용자 정보를 UserDetails로 래핑
+ * - 권한, 계정상태 등 인증 관련 정보를 제공
+ */
 @RequiredArgsConstructor
 public class CustomUserDetails implements UserDetails {
 
+    // 인증된 유저 엔티티
     private final User user;
 
-
+    /**
+     * 사용자 권한 반환 (ex: ROLE_USER, ROLE_ADMIN)
+     */
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + user.getRole().name()));
+        return Collections.singletonList(
+                new SimpleGrantedAuthority("ROLE_" + user.getRole().name())
+        );
     }
+
+    /**
+     * 인증 객체에서 User 엔티티 직접 반환 (편의 메서드)
+     */
     public User getUser() {
         return user;
     }
 
+    /** 패스워드 반환 */
     @Override
     public String getPassword() {
         return user.getUserPassword();
     }
 
+    /** username 반환 (로그인시 사용하는 아이디) */
     @Override
     public String getUsername() {
         return user.getUserId();
     }
 
+    /** 계정 만료 여부 (true: 만료X) */
     @Override
     public boolean isAccountNonExpired() {
         return true;
     }
 
+    /** 계정 잠김 여부 (true: 잠김X) */
     @Override
     public boolean isAccountNonLocked() {
         return true;
     }
 
+    /** 인증정보 만료 여부 (true: 만료X) */
     @Override
     public boolean isCredentialsNonExpired() {
         return true;
     }
 
+    /** 활성화 여부 (true: 활성화) */
     @Override
     public boolean isEnabled() {
         return true;
     }
 
+    /** User 엔티티의 PK 반환 (추가 편의 메서드) */
     public Long getUserId() {
         return user.getId();
     }

--- a/src/main/java/com/balgoorm/balgoorm_backend/user/auth/CustomUserDetailsService.java
+++ b/src/main/java/com/balgoorm/balgoorm_backend/user/auth/CustomUserDetailsService.java
@@ -8,17 +8,28 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
+/**
+ * Spring Security 인증을 위한 UserDetailsService 구현체
+ * - 로그인 시 DB에서 유저 정보를 조회하여 UserDetails(Principal)로 반환
+ */
 @Service
 @RequiredArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {
 
     private final UserRepository userRepository;
 
+    /**
+     * username(userId)로 DB에서 User 엔티티 조회
+     * @param username 프론트에서 전달한 userId (스프링 시큐리티는 username으로 전달)
+     * @return 인증에 사용할 UserDetails 구현체
+     * @throws UsernameNotFoundException 유저를 찾지 못하면 예외 발생
+     */
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        User user = userRepository.findByUserId(username).orElseThrow(() -> {
-            return new UsernameNotFoundException("회원 정보를 찾을 수 없습니다.");
-        });
+        // userId로 유저를 찾고, 없으면 예외 발생
+        User user = userRepository.findByUserId(username)
+                .orElseThrow(() -> new UsernameNotFoundException("회원 정보를 찾을 수 없습니다."));
+        // 인증에 사용할 UserDetails 객체로 변환하여 반환
         return new CustomUserDetails(user);
     }
 }

--- a/src/main/java/com/balgoorm/balgoorm_backend/user/config/SecurityConfig.java
+++ b/src/main/java/com/balgoorm/balgoorm_backend/user/config/SecurityConfig.java
@@ -9,50 +9,48 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
-import org.springframework.stereotype.Component;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-import org.springframework.web.filter.CorsFilter;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.stereotype.Component;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Map;
 
-import static org.springframework.security.config.Customizer.withDefaults;
-
-@Configuration
-@EnableWebSecurity
+@Configuration // 스프링 빈 등록(설정 클래스)
+@EnableWebSecurity // 스프링 시큐리티 활성화
 public class SecurityConfig {
 
+    // 사용자 인증정보 및 로그인 성공 핸들러 주입
     private final CustomUserDetailsService customUserDetailsService;
     private final CustomAuthenticationSuccessHandler customAuthenticationSuccessHandler;
 
+    // 생성자 주입 (의존성)
     public SecurityConfig(CustomUserDetailsService customUserDetailsService, CustomAuthenticationSuccessHandler customAuthenticationSuccessHandler) {
         this.customUserDetailsService = customUserDetailsService;
         this.customAuthenticationSuccessHandler = customAuthenticationSuccessHandler;
     }
 
+    // 비밀번호 암호화 전략(BCrypt) 등록
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 
-
+    // CORS 정책 설정 (프론트와 API 서버 도메인 분리 시 필요)
     @Bean
     CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOriginPatterns(Arrays.asList("http://localhost:3000/","*"));
+        // 운영 환경에서는 * 대신 실제 도메인 명시!
+        configuration.setAllowedOriginPatterns(Arrays.asList("http://localhost:3000"));
         configuration.setAllowedMethods(Arrays.asList("GET","POST","PUT","DELETE"));
         configuration.setAllowedHeaders(Arrays.asList("*"));
         configuration.setAllowCredentials(true);
@@ -61,54 +59,63 @@ public class SecurityConfig {
         return source;
     }
 
+    // 보안 정책의 핵심: SecurityFilterChain Bean 등록 (스프링 시큐리티 5.7 이상)
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
         httpSecurity
+                // CSRF(위조공격) 방지 비활성화 (API 서버라면 대부분 사용)
                 .csrf(AbstractHttpConfigurer::disable)
+                // CORS 정책 적용
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                // URL 패턴별 접근 권한 설정
                 .authorizeHttpRequests(auth -> auth
-
-                        .requestMatchers( "/css/**", "/js/**", "/img/**", "/font/**", "/error").permitAll()
-                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
-                        .requestMatchers("/api/myinfo/**").hasAnyRole("ADMIN","USER")
-                        .requestMatchers("/api/login", "/api/signup", "/api/logout", "/api/test/**").permitAll()
-                        .anyRequest().hasAnyRole("ADMIN", "USER")
+                        .requestMatchers("/css/**", "/js/**", "/img/**", "/font/**", "/error").permitAll() // 정적 자원/에러페이지 모두 허용
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN")                                // 관리자 권한 필요
+                        .requestMatchers("/api/myinfo/**").hasAnyRole("ADMIN","USER")                    // 관리자/일반유저 모두 접근 가능
+                        .requestMatchers("/api/login", "/api/signup", "/api/logout", "/api/test/**").permitAll() // 인증/회원가입/로그아웃 허용
+                        .anyRequest().hasAnyRole("ADMIN", "USER") // 그 외 모든 요청은 인증 필요
                 )
+                // 폼 로그인 방식(백엔드 단독 로그인 API 처리)
                 .formLogin(login -> login
-                        .loginPage("/login")
-                        .loginProcessingUrl("/api/login")
-                        .successHandler(customAuthenticationSuccessHandler)
-                        .failureHandler((request, response, exception) -> {
+                        .loginPage("/login")                          // (REST라면 의미 없음, 프론트엔드에서 폼 제공)
+                        .loginProcessingUrl("/api/login")             // 실제 로그인 요청 API
+                        .successHandler(customAuthenticationSuccessHandler) // 로그인 성공시 커스텀 동작
+                        .failureHandler((request, response, exception) -> { // 로그인 실패 응답
                             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
                             response.setContentType("application/json");
                             response.getWriter().write("{\"error\": \"Invalid username or password.\"}");
                         })
-                        .usernameParameter("userId")
-                        .passwordParameter("userPassword")
+                        .usernameParameter("userId")                  // 로그인 form에서 id 필드명
+                        .passwordParameter("userPassword")            // 로그인 form에서 pw 필드명
                         .permitAll()
                 )
+                // 로그아웃 설정
                 .logout(logout -> logout
-                        .logoutUrl("/api/logout")
-                        .logoutSuccessHandler(customLogoutSuccessHandler())
-                        .invalidateHttpSession(true)
-                        .clearAuthentication(true)
-                        .deleteCookies("JSESSIONID")
+                        .logoutUrl("/api/logout")                     // 로그아웃 API 경로
+                        .logoutSuccessHandler(customLogoutSuccessHandler()) // 커스텀 핸들러 적용
+                        .invalidateHttpSession(true)                  // 세션 무효화
+                        .clearAuthentication(true)                    // 인증 정보 삭제
+                        .deleteCookies("JSESSIONID")                  // 쿠키 삭제
                 )
+                // 세션 관리 정책
                 .sessionManagement(session -> session
-                        .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
-                        .maximumSessions(1)
-                        .maxSessionsPreventsLogin(false)
+                        .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED) // 세션은 필요할 때만 생성
+                        .maximumSessions(1)                                      // 동시 접속 1개 제한
+                        .maxSessionsPreventsLogin(false)                         // 중복 로그인 허용
                 )
+                // 사용자 인증정보 서비스 등록
                 .userDetailsService(customUserDetailsService);
 
         return httpSecurity.build();
     }
 
+    // 로그아웃 성공시 커스텀 핸들러 Bean 등록
     @Bean
     public LogoutSuccessHandler customLogoutSuccessHandler() {
         return new CustomLogoutSuccessHandler();
     }
 
+    // 실제 로그아웃 성공시 JSON 메시지 반환 (내부 static class)
     @Component
     public static class CustomLogoutSuccessHandler implements LogoutSuccessHandler {
 
@@ -118,7 +125,8 @@ public class SecurityConfig {
         public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
             response.setStatus(HttpServletResponse.SC_OK);
             response.setContentType("application/json;charset=UTF-8");
-            response.getWriter().write(objectMapper.writeValueAsString("Spring: 로그아웃 성공"));
+            // {"message": "로그아웃 성공"} 형태로 응답
+            response.getWriter().write(objectMapper.writeValueAsString(Map.of("message", "로그아웃 성공")));
             response.getWriter().flush();
         }
     }

--- a/src/main/java/com/balgoorm/balgoorm_backend/user/model/entity/User.java
+++ b/src/main/java/com/balgoorm/balgoorm_backend/user/model/entity/User.java
@@ -3,9 +3,11 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 import java.time.LocalDateTime;
 
-
+@Setter
 @Getter
 @Entity
 @NoArgsConstructor
@@ -19,9 +21,11 @@ public class User {
     @Column(nullable = false, unique = true)
     private String userId;
 
+    @Setter
     @Column(nullable = false)
     private String userPassword;
 
+    @Setter
     @Column(nullable = false)
     private String nickname;
 


### PR DESCRIPTION
## 주요 변경 내용

- 서버 구동 시 admin 계정이 없을 때 자동으로 생성하는 DataInitializer 코드를 리팩토링하였습니다.
- 관리자 계정의 아이디, 비밀번호, 닉네임, 이메일을 상수로 분리하여 코드 가독성과 유지보수성을 높였습니다.
- User 엔티티의 생성일(createDate) 자동화에 따라, 빌더에서 생성일 인자를 제거하였습니다.
- 코드에 상세 주석을 추가하여 동작 목적과 초기화 로직을 쉽게 이해할 수 있도록 했습니다.

## 기대 효과

- 계정 정보 변경/관리의 용이성 및 초기화 코드의 가독성 향상
- 엔티티의 생성일 관리 일관성 확보
- 협업 및 코드 리뷰 시 의도 파악이 쉬워지고 실수 가능성 감소

---

